### PR TITLE
Update base.py

### DIFF
--- a/metrics2mqtt/base.py
+++ b/metrics2mqtt/base.py
@@ -32,7 +32,7 @@ class MQTTMetrics(object):
         self.deferred_metrics_queue = queue.Queue()
 
     def connect(self):
-        self.client = mqtt.Client(self.system_name + '_metrics2mqtt')
+        self.client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1, self.system_name + '_metrics2mqtt')
         try: 
             if self.username or self.password:
                 self.client.username_pw_set(self.username, self.password)


### PR DESCRIPTION
backwards compatible with mqtt API v1
https://stackoverflow.com/questions/77984857/paho-mqtt-unsupported-callback-api-version-error