### PR TITLE
Update metrics.py

### DIFF
--- a/metrics2mqtt/metrics.py
+++ b/metrics2mqtt/metrics.py
@@ -32,7 +32,7 @@ class BaseMetric(object):
         return config_topic
 
     def sanitize(self, val):
-        return val.lower().replace(" ", "_").replace("/","_")
+        return val.lower().replace(" ", "_").replace("/","_").replace(".","_")
 
     def poll(self, result_queue=None):
         raise NotImplementedError


### PR DESCRIPTION
replace . in system name to prevent homeassistant error: [homeassistant.components.mqtt.discovery] Received message on illegal discovery topic 'homeassistant/sensor/macbook-pro.local/disk_usage__/config'. The **topic** contains not allowed characters. For more information see https://www.home-assistant.io/integrations/mqtt/#discovery-topic